### PR TITLE
LIBITD-2487. Fix Jenkinsfile for Jenkins v2.440.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,12 +108,14 @@ pipeline {
       steps {
         sh '''
           . .venv/bin/activate
-          pytest -v --junitxml=reports/results.xml -o junit_family=xunit1
+          pytest --cov-report xml:reports/coverage.xml --cov=whpool -v --junitxml=reports/results.xml -o junit_family=xunit1
         '''
       }
       post {
         always {
           junit '**/reports/results.xml'
+
+          recordCoverage(tools: [[parser: 'COBERTURA', pattern: 'reports/coverage.xml']])
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,7 +130,9 @@ pipeline {
       post {
         always {
           // Collect pycodestyle reports
-          recordIssues(tools: [pyLint(reportEncoding: 'UTF-8', name: 'ruff check')], unstableTotalAll: 1)
+          recordIssues(tools: [pyLint(reportEncoding: 'UTF-8', name: 'ruff check')],
+                       qualityGates: [[threshold: 1, type: 'TOTAL', criticality: 'UNSTABLE']]
+          )
         }
       }
     }


### PR DESCRIPTION
Updated the "recordIssues" directive in the "Jenkinsfile" to use the "qualityGates" parameter, instead of the obsolete "unstableTotalAll" parameter.

https://umd-dit.atlassian.net/browse/LIBITD-2487